### PR TITLE
Clean up code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,11 +47,19 @@ impl Config {
   }
 
   fn parse_config_file() -> ConfigFile {
-    let path = dirs::config_dir().unwrap().join("figma-font-helper");
+    let path = dirs::config_dir()
+      .expect("Unable to retrieve the config directory")
+      .join("figma-font-helper");
 
     let mut config = ConfigFile {
       port: "18412".to_owned(),
-      directories: vec![String::from("/usr/share/fonts"), dirs::font_dir().unwrap().display().to_string()],
+      directories: vec![
+        String::from("/usr/share/fonts"),
+        dirs::font_dir()
+          .expect("Unable to retrieve the font directory")
+          .to_string_lossy()
+          .into_owned()
+      ],
     };
 
     if path.exists() {

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,10 @@ pub fn init() {
     "font_helper=debug, finder=debug, libfonthelper=debug, simple_server=info",
   )
   .log_to_file()
-  .directory(dirs::config_dir().unwrap().join("figma-font-helper/log").display().to_string())
+  .directory(
+    dirs::config_dir()
+      .expect("Unable to retrieve the config directory")
+      .join("figma-font-helper/log"))
   .format(opt_format)
   .start()
   .unwrap();


### PR DESCRIPTION
Replaced `.unwrap()` with `.expect()` calls to give a bit of info when the expression returns an `Result::Err` and not just panics.

also removed the unnecessary conversion from `PathBuf` into a `String` since the function 
`.directory()` of `flexi_logger::Logger` accepts `Into<PathBuf>`.